### PR TITLE
fix(windows): use junction symlink

### DIFF
--- a/src/link-package/symlink-package.ts
+++ b/src/link-package/symlink-package.ts
@@ -27,6 +27,13 @@ export const symlinkPackage = async (
 	await symlink(
 		targetPath,
 		symlinkPath,
+
+		/**
+		 * On Windows, 'dir' requires admin privileges so use 'junction' instead
+		 *
+		 * npm also uses junction:
+		 * https://github.com/npm/cli/blob/v9.9.3/workspaces/arborist/lib/arborist/reify.js#L738
+		 */
 		'junction',
 	);
 

--- a/src/link-package/symlink-package.ts
+++ b/src/link-package/symlink-package.ts
@@ -27,7 +27,7 @@ export const symlinkPackage = async (
 	await symlink(
 		targetPath,
 		symlinkPath,
-		'dir',
+		'junction',
 	);
 
 	await linkBinaries(


### PR DESCRIPTION
Junctions don't require admin privileges on Windows and symlinks do. `npm link` uses junctions and this change only afects Windows users.