### PR TITLE
Add watch flag for publish command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ import publish from './commands/publish';
 			},
 		);
 	} else if (argv.command === 'publish') {
-		await publish.handler(cwdProjectPath, argv._);
+		await publish.handler(cwdProjectPath, argv._, argv.flags);
 	}
 })().catch((error) => {
 	console.error('Error:', error.message);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -12,6 +12,7 @@ import { hardlink } from '../utils/symlink';
 const linkPackage = async (
 	basePackagePath: string,
 	linkPackagePath: string,
+	watch?: boolean,
 ) => {
 	const absoluteLinkPackagePath = path.resolve(basePackagePath, linkPackagePath);
 	const packageJson = await readPackageJson(absoluteLinkPackagePath);
@@ -105,11 +106,11 @@ export default {
 		name: 'publish',
 		parameters: ['<package paths...>'],
 		flags: {
-			// watch: {
-			// 	type: Boolean,
-			// 	alias: 'w',
-			// 	description: 'Watch for changes in the package and automatically relink',
-			// },
+			watch: {
+				type: Boolean,
+				alias: 'w',
+				description: 'Watch for changes in the package and automatically relink',
+			},
 		},
 		help: {
 			description: 'Link a package to simulate an environment similar to `npm install`',
@@ -119,6 +120,7 @@ export default {
 	handler: async (
 		cwdProjectPath: string,
 		packagePaths: string[],
+		flags: { watch?: boolean, help?: boolean},
 	) => {
 		if (packagePaths.length > 0) {
 			await Promise.all(
@@ -126,6 +128,7 @@ export default {
 					linkPackagePath => linkPackage(
 						cwdProjectPath,
 						linkPackagePath,
+						flags.watch,
 					),
 				),
 			);


### PR DESCRIPTION
This PR adds a `--watch` flag to the publish command. If the source file is deleted and re-created (as is the case for some build systems, such as https://github.com/callstack/react-native-builder-bob), then the `--watch` flag will re-establish the hard link with the new file in the source file path.